### PR TITLE
Remove spaces before each rule from sendRules

### DIFF
--- a/functions/src/telegram/commands/rules.ts
+++ b/functions/src/telegram/commands/rules.ts
@@ -10,27 +10,27 @@ export function rules(
     `
 *Regolamento*:
 
-  ✅ Richieste di supporto *solo se specifiche, chiare, concise e accompagnate dalle soluzioni già provate*\\. Il gruppo non è qui per imboccarti la soluzione\\. Siate pro\\-attivi\\.
+✅ Richieste di supporto *solo se specifiche, chiare, concise e accompagnate dalle soluzioni già provate*\\. Il gruppo non è qui per imboccarti la soluzione\\. Siate pro\\-attivi\\.
 
-  ✅ Offerte di lavoro *solo se accompagnate da tipo di contratto e range di retribuzione* \\(o budget\\)\\. Pena la cancellazione del messaggio\\.
+✅ Offerte di lavoro *solo se accompagnate da tipo di contratto e range di retribuzione* \\(o budget\\)\\. Pena la cancellazione del messaggio\\.
 
-  ✅ Discussioni su news, lavoro e lifestyle del web developer e affini\\.
+✅ Discussioni su news, lavoro e lifestyle del web developer e affini\\.
 
-  ❌ Richieste di aiuto in privato\\. Il gruppo è qui per aiutare e per parlare\\. No, non intasi il flusso di chat con i tuoi problemi se chiedi qui\\. Scrivi /nonchiederedichiedere per il motivo\\.
+❌ Richieste di aiuto in privato\\. Il gruppo è qui per aiutare e per parlare\\. No, non intasi il flusso di chat con i tuoi problemi se chiedi qui\\. Scrivi /nonchiederedichiedere per il motivo\\.
 
-  ❌ Richieste di supporto per esercizi scolastici\\. Va bene richiedere risorse per risolvere autonomamente il problema\\.
+❌ Richieste di supporto per esercizi scolastici\\. Va bene richiedere risorse per risolvere autonomamente il problema\\.
 
-  ❌ Richieste di supporto non inerenti allo sviluppo web\\. Nessuno qui riparerà la tua stampante o creerà un plugin per il tuo server Minecraft\\.
+❌ Richieste di supporto non inerenti allo sviluppo web\\. Nessuno qui riparerà la tua stampante o creerà un plugin per il tuo server Minecraft\\.
 
-  ❌ Incollare codice direttamente in chat \\(tranne che per snippet brevi\\)\\. Utilizza servizi come Pastebin, Codepen o Stackblitz\\.
+❌ Incollare codice direttamente in chat \\(tranne che per snippet brevi\\)\\. Utilizza servizi come Pastebin, Codepen o Stackblitz\\.
 
-  ❌ Spam di qualsiasi forma nel flusso di chat\\.
+❌ Spam di qualsiasi forma nel flusso di chat\\.
 
-  ❌ Foto agli schermi\\. Sono accettati screenshot\\. Impara ad usare gli strumenti della tua macchina\\.
+❌ Foto agli schermi\\. Sono accettati screenshot\\. Impara ad usare gli strumenti della tua macchina\\.
 
-  ❌ Gore, porno, nudità e tutto ciò che può urtare la sensibilità dei membri del gruppo\\. Valido anche per le foto profilo\\. Nel gruppo sono presenti membri minorenni\\.
+❌ Gore, porno, nudità e tutto ciò che può urtare la sensibilità dei membri del gruppo\\. Valido anche per le foto profilo\\. Nel gruppo sono presenti membri minorenni\\.
 
-  ❌ Mandare messaggi con canali invece del proprio profilo personale\\.
+❌ Mandare messaggi con canali invece del proprio profilo personale\\.
 
 Gli utenti sono tenuti a evitare comportamenti inadeguati, al fine di mantenere stabile e non tossica la situazione nella chat\\.
 Gli amministratori possono bandire qualunque membro dalla chat qualora possa venir identificato come potenziale problema\\. Nessuno deve spiegazioni a nessuno\\.


### PR DESCRIPTION
While spaces are great to indent lists, they look a bit off on Telegram if used on big walls of text like the bot's `/regole` command. 