### PR TITLE
Ban automatico su scrittura con canale

### DIFF
--- a/functions/src/telegram/bot.ts
+++ b/functions/src/telegram/bot.ts
@@ -1,6 +1,7 @@
 import * as functions from "firebase-functions";
 import { Telegraf, Context } from "telegraf";
 import { bindCommands } from "./bindCommands";
+import { noChannelUserBan } from "./noChannelUserBan";
 import { setLastMemberActivity } from "./setLastMemberActivity";
 
 const telegramBot: Telegraf<Context> = new Telegraf(
@@ -9,6 +10,7 @@ const telegramBot: Telegraf<Context> = new Telegraf(
 
 bindCommands(telegramBot);
 telegramBot.on("message", setLastMemberActivity);
+telegramBot.on("message", noChannelUserBan);
 
 export const bot = functions
 	.region("europe-west1")

--- a/functions/src/telegram/noChannelUserBan.ts
+++ b/functions/src/telegram/noChannelUserBan.ts
@@ -1,0 +1,20 @@
+import type { Context } from "telegraf";
+
+export const noChannelUserBan = async (context: Context) => {
+	if (context.message?.from.username !== "Channel_Bot") {
+		return;
+	}
+
+	if (!context.message.sender_chat) {
+		return;
+	}
+
+	await Promise.all([
+		context.banChatSenderChat(context.message.sender_chat.id),
+		context.deleteMessage(context.message.message_id),
+	]);
+
+	return context.replyWithMarkdownV2(
+		`_Un messaggio inviato da un canale è stato eliminato per violazione delle regole\\._`,
+	);
+};


### PR DESCRIPTION
Questa PR introduce il check da parte del bot sui messaggi scritti con un canale. I canali non sono ammessi dentro al gruppo, quindi il messaggio viene cancellato e il canale bannato.