### PR TITLE
[broken pr] Rinominati Jobs per nektos/act

### DIFF
--- a/.github/workflows/close_issue_telegram_notify.yml
+++ b/.github/workflows/close_issue_telegram_notify.yml
@@ -6,7 +6,7 @@ on:
       - closed
 
 jobs:
-  notify:
+  notify_issue_close:
     name: Notify
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/open_issue_telegram_notify.yml
+++ b/.github/workflows/open_issue_telegram_notify.yml
@@ -7,7 +7,7 @@ on:
       - opened
 
 jobs:
-  notify:
+  notify_issue_open:
     name: Notify
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/open_pr_telegram_notify.yml
+++ b/.github/workflows/open_pr_telegram_notify.yml
@@ -7,7 +7,7 @@ on:
       - opened
 
 jobs:
-  notify:
+  notify_pr_open:
     name: Notify
     runs-on: ubuntu-latest
     steps:

--- a/functions/src/telegram/bot.ts
+++ b/functions/src/telegram/bot.ts
@@ -1,6 +1,7 @@
 import * as functions from "firebase-functions";
 import { Telegraf, Context } from "telegraf";
 import { bindCommands } from "./bindCommands";
+import { noChannelUserBan } from "./noChannelUserBan";
 import { setLastMemberActivity } from "./setLastMemberActivity";
 
 const telegramBot: Telegraf<Context> = new Telegraf(
@@ -9,6 +10,7 @@ const telegramBot: Telegraf<Context> = new Telegraf(
 
 bindCommands(telegramBot);
 telegramBot.on("message", setLastMemberActivity);
+telegramBot.on("message", noChannelUserBan);
 
 export const bot = functions
 	.region("europe-west1")

--- a/functions/src/telegram/noChannelUserBan.ts
+++ b/functions/src/telegram/noChannelUserBan.ts
@@ -1,0 +1,20 @@
+import type { Context } from "telegraf";
+
+export const noChannelUserBan = async (context: Context) => {
+	if (context.message?.from.username !== "Channel_Bot") {
+		return;
+	}
+
+	if (!context.message.sender_chat) {
+		return;
+	}
+
+	await Promise.all([
+		context.banChatSenderChat(context.message.sender_chat.id),
+		context.deleteMessage(context.message.message_id),
+	]);
+
+	return context.replyWithMarkdownV2(
+		`_Un messaggio inviato da un canale è stato eliminato per violazione delle regole\\._`,
+	);
+};


### PR DESCRIPTION
Ho rinominato i jobs delle Github Actions per migliorare l'esperienza di test con [nectos/act](https://github.com/nektos/act).

Tramite `act` è possibile eseguire ad esempio:

```
act -j notify_pr_open
```

Per eseguire un job specifico. Avendo i nomi corrispondenti, tutti i job venivano eseguiti.

In alternativa si può anche eseguire

```
act pull_request
```

Per eseguire tutti i job di una PR.