### PR TITLE
Renamed jobs to improve act usage experience

### DIFF
--- a/.github/workflows/close_issue_telegram_notify.yml
+++ b/.github/workflows/close_issue_telegram_notify.yml
@@ -6,7 +6,7 @@ on:
       - closed
 
 jobs:
-  notify:
+  notify_issue_close:
     name: Notify
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/open_issue_telegram_notify.yml
+++ b/.github/workflows/open_issue_telegram_notify.yml
@@ -7,7 +7,7 @@ on:
       - opened
 
 jobs:
-  notify:
+  notify_issue_open:
     name: Notify
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/open_pr_telegram_notify.yml
+++ b/.github/workflows/open_pr_telegram_notify.yml
@@ -7,7 +7,7 @@ on:
       - opened
 
 jobs:
-  notify:
+  notify_pr_open:
     name: Notify
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ho rinominato i jobs delle Github Actions per migliorare l'esperienza di test con [nectos/act](https://github.com/nektos/act).

Tramite `act` è possibile eseguire ad esempio:

```
act -j notify_pr_open
```

Per eseguire un job specifico. Avendo i nomi corrispondenti, tutti i job venivano eseguiti.

In alternativa si può anche eseguire

```
act pull_request
```

Per eseguire tutti i job di una PR.